### PR TITLE
Correct AuthModule sharing

### DIFF
--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -1,11 +1,12 @@
 import { Module } from "@nestjs/common";
 
 import { AuthService } from "./auth.service";
-import { DatabaseService } from "../database/database.service";
+import { DatabaseModule } from "../database/database.module";
 
 
 @Module({
-    components: [AuthService]
+    modules: [DatabaseModule],
+    components: [AuthService],
+    exports: [AuthService]
 })
-
 export class AuthModule { }

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -13,12 +13,8 @@ export class AuthService {
     constructor(private databaseService: DatabaseService) {
     }
 
-    protected get repository(): Promise<Repository<User>> {
-        return this.databaseService.getRepository(User);
-    }
-
     public async getRolesByUserId(userId: number): Promise<Role[]> {
-        let user: User = await (await this.repository)
+        let user: User = await (await this.databaseService.getRepository(User))
             .createQueryBuilder("user")
             .where("user.id=:userId")
             .leftJoinAndSelect("user.roles", "roles")

--- a/src/modules/categories/category.module.ts
+++ b/src/modules/categories/category.module.ts
@@ -1,5 +1,6 @@
 import { MiddlewaresConsumer, Module } from "@nestjs/common";
 
+import { AuthModule } from "../auth/auth.module";
 import { AuthService } from "../auth/auth.service";
 import { DatabaseModule } from "../database/database.module";
 import { DatabaseConfig } from "../database/database.config";
@@ -12,10 +13,9 @@ import { AuthenticateMiddleware } from "../../middleware/authenticate.middleware
 
 
 @Module({
-    modules: [DatabaseModule],
+    modules: [DatabaseModule, AuthModule],
     controllers: [CategoryController],
     components: [
-        AuthService,
         CategoryService,
         { provide: DatabaseConfig, useClass: DevDatabaseConfig },
     ],

--- a/src/modules/roles/role.module.ts
+++ b/src/modules/roles/role.module.ts
@@ -1,6 +1,6 @@
 import { Module, MiddlewaresConsumer } from "@nestjs/common";
 
-import { AuthService } from "../auth/auth.service";
+import { AuthModule } from "../auth/auth.module";
 import { RoleService } from "./role.service";
 import { RoleController } from "./role.controller";
 import { DatabaseConfig } from "../database/database.config";
@@ -12,10 +12,9 @@ import { AuthenticateMiddleware } from "../../middleware/authenticate.middleware
 
 
 @Module({
-    modules: [DatabaseModule],
+    modules: [DatabaseModule, AuthModule],
     controllers: [RoleController],
     components: [
-        AuthService,
         RoleService,
         { provide: DatabaseConfig, useClass: DevDatabaseConfig }
     ],

--- a/src/modules/users/user.module.ts
+++ b/src/modules/users/user.module.ts
@@ -1,6 +1,6 @@
-import { AuthService } from "../auth/auth.service";
 import { Module, MiddlewaresConsumer } from "@nestjs/common";
 
+import { AuthModule } from "../auth/auth.module";
 import { UserService } from "./user.service";
 import { UserController } from "./user.controller";
 import { DatabaseConfig } from "../database/database.config";
@@ -12,10 +12,9 @@ import { AuthenticateMiddleware } from "../../middleware/authenticate.middleware
 
 
 @Module({
-    modules: [DatabaseModule],
+    modules: [DatabaseModule, AuthModule],
     controllers: [UserController],
     components: [
-        AuthService,
         UserService,
         { provide: DatabaseConfig, useClass: DevDatabaseConfig }
     ],


### PR DESCRIPTION
1. Since `AuthModule` need db, it should import `DatabaseModule`.
2. Since we need to inject `AuthService` in middlewares related to couple of modules, we should export it from module
3. User/Role/Category modules should import `AuthModule`, because it needs it for authenticate middleware

**P.S.** I dislike getter of user repository in `AuthService`. In future we also will use other repositories (role repository etc.).
